### PR TITLE
Add Cornell CSL BRG's Lizard core to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Zero-riscy | ETH Zurich, Università di Bologna | [GitHub](https://github.com/pu
 Ariane | ETH Zurich, Università di Bologna | [Website](https://pulp-platform.github.io/ariane/docs/home/),[GitHub](https://github.com/pulp-platform/ariane) | 1.11-draft | RV64GC | Solderpad Hardware License v. 0.51
 Riscy Processors | MIT CSAIL CSG | [Website](http://csg.csail.mit.edu/riscy-e/),[GitHub](https://github.com/csail-csg/riscy) | | | MIT
 RiscyOO | MIT CSAIL CSG | [GitHub](https://github.com/csail-csg/riscy-OOO) | 1.10 | RV64IMAFD | MIT
+Lizard | Cornell CSL BRG | [GitHub](https://github.com/cornell-brg/lizard) | | RV64IM | BSD
 Minerva | LambdaConcept | [GitHub](https://github.com/lambdaconcept/minerva) | 1.10 | RV32I | BSD
 OPenV/mriscv | OnChipUIS | [GitHub](https://github.com/onchipuis/mriscv) | | RV32I(?) | MIT
 VexRiscv | SpinalHDL | [GitHub](https://github.com/SpinalHDL/VexRiscv) | | RV32I[M][C] | MIT
@@ -51,7 +52,7 @@ Icicle | Graham Edgecombe | [GitHub](https://github.com/grahamedgecombe/icicle) 
 
 ## SoCs
 
-Include a chip if it has been fabricated and is either available for sale, available for preorder, or running production workloads internally, and if it has at least one RISC-V hard core (no FPGAs, but non-"SoC" products 
+Include a chip if it has been fabricated and is either available for sale, available for preorder, or running production workloads internally, and if it has at least one RISC-V hard core (no FPGAs, but non-"SoC" products
  with controller cores are allowed).
 
 Name | Supplier | Links | Core | ISA | Devkit | Availability


### PR DESCRIPTION
We would like to add The Lizard Core (an RV64IM out-of-order processor) designed by the Batten Research Group (part of Cornell University's CSL) to the RISC-V core list.
 