### PR TITLE
Add ESP to SoC platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ FreeStart AE250 | Andes | [Website](http://freestart.andestech.com/) | N22 | And
 Standard AE250 | Andes | [Website](http://www.andestech.com/en/products-solutions/andeshape-platforms/ae250-ahb-based-platform-pre-integrated-with-n22/), [IDE](http://www.andestech.com/en/products-solutions/andesight-ide/) | N22 | Andes Commerical License
 AE350 | Andes | [Website](http://www.andestech.com/en/products-solutions/andeshape-platforms/ae350-axi-based-platform-pre-integrated-with-n25f-nx25f-a25-ax25/), [IDE](http://www.andestech.com/en/products-solutions/andesight-ide/) | N25F, D25F, A25, A25MP, NX25F, AX25, AX25MP | Andes Commerical License
 SCR1 SDK | Syntacore | [GitHub](https://github.com/syntacore/scr1-sdk) | SCR1, SCRx | SHL 2.0 
+ESP | SLD Group, Columbia University | [Website](https://esp.cs.columbia.edu), [GitHub](https://github.com/sld-columbia/esp) | Ariane | Apache 2.0
 
 ## SoCs
 


### PR DESCRIPTION
ESP is an open-source heterogeneous SoC platform. It allows users to quickly create instances of a RISC-V based SoC that integrates the Ariane processor core together with multiple accelerators.
Each component is hosted in a tile connected the node of a configurable network on chip.

The repository provides examples of accelerators designed with high-level synthesis and Chisel.
In addition, ESP integrates the NVIDIA Deep Learning Accelerator as an example of third-party IP block.

ESP includes automation scripts to facilitate the design of custom accelerators and the corresponding software stack.