### PR TITLE
Add RSD to the cores list

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ BI-350 | CloudBEAR | [Website](https://cloudbear.ru/bi_350.html) | 1.10 | RV32IM
 BI-651 | CloudBEAR | [Website](https://cloudbear.ru/bi_651.html) | 1.10 | RV64GC + multi-core | SystemVerilog | CloudBEAR Commercial License
 BI-671 | CloudBEAR | [Website](https://cloudbear.ru/bi_671.html) | 1.10 | RV64GC + multi-core | SystemVerilog | CloudBEAR Commercial License
 SSRV | risclite | [Website](https://risclite.github.io/),[GitHub](https://github.com/risclite/SuperScalar-RISCV-CPU) | 1.10 | RV32IMC | Verilog | Apache 2.0
+RSD | rsd-devel | [GitHub](https://github.com/rsd-devel/rsd) | | RV32IM | SystemVerilog | Apache 2.0
 
 ## SoC platforms
 


### PR DESCRIPTION
RSD is a RISC-V out-of-order superscalar processor written in SystemVerilog.
RSD can run on a Xilinx Zynq FPGA board and can be simulated with Mentor Modelsim/QuestaSim, Verilator, and Vivado.
