### PR TITLE
Add Pluto and PQSoC from PQShield

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ BI-651 | CloudBEAR | [Website](https://cloudbear.ru/bi_651.html) | 1.10 | RV64GC
 BI-671 | CloudBEAR | [Website](https://cloudbear.ru/bi_671.html) | 1.10 | RV64GC + multi-core | SystemVerilog | CloudBEAR Commercial License
 SSRV | risclite | [Website](https://risclite.github.io/),[GitHub](https://github.com/risclite/SuperScalar-RISCV-CPU) | 1.10 | RV32IMC | Verilog | Apache 2.0
 RSD | rsd-devel | [GitHub](https://github.com/rsd-devel/rsd) | | RV32IM | SystemVerilog | Apache 2.0
+Pluto | PQShield | [Website](https://pqsoc.com) | 1.11 | RV32I[M][C] / RV32E[M][C] + Crypto Functions | Verilog | PQShield Commercial License
 
 ## SoC platforms
 
@@ -91,6 +92,7 @@ Standard AE250 | Andes | [Website](http://www.andestech.com/en/products-solution
 AE350 | Andes | [Website](http://www.andestech.com/en/products-solutions/andeshape-platforms/ae350-axi-based-platform-pre-integrated-with-n25f-nx25f-a25-ax25/), [IDE](http://www.andestech.com/en/products-solutions/andesight-ide/) | N25F, D25F, A25, A25MP, NX25F, AX25, AX25MP | Andes Commerical License
 SCR1 SDK | Syntacore | [GitHub](https://github.com/syntacore/scr1-sdk) | SCR1, SCRx | SHL 2.0
 ESP | SLD Group, Columbia University | [Website](https://esp.cs.columbia.edu), [GitHub](https://github.com/sld-columbia/esp) | Ariane | Apache 2.0
+PQSoC | PQShield | [Website](https://pqsoc.com) | Pluto | PQShield Commercial License
 
 ## SoCs
 


### PR DESCRIPTION
We recently joined the RISC-V Foundation and are making these products commercially available. Initial information is available at pqsoc.com while we will update our main web pages.
The release will happen over the spring but the Pluto RISC-V core and the the SoC platform are running and can be packaged for third party verification. 