### PR TITLE
added neorv32

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ E7 | SiFive | [Website](https://www.sifive.com/cores/e76) | 1.11 | RV32I(E)MAFDC
 S7 | SiFive | [Website](https://www.sifive.com/cores/s76) | 1.11 | RV64GC 2.2 | Verilog | SiFive commercial license
 U7 | SiFive | [Website](https://www.sifive.com/cores/u74) | 1.11 | RV64GC 2.2 | Verilog | SiFive commercial license
 Kronos | Sonal Pinto | [GitHub](https://github.com/SonalPinto/kronos) | | RV32I | SystemVerilog | Apache 2.0
+NEORV32 | Stephan Nolting | [GitHub](https://github.com/stnolting/neorv32) | 1.12-draft | 2.2, RV32[I/E][M][C] | VHDL | BSD
 
 ## SoC platforms
 


### PR DESCRIPTION
I would kindly ask to add my RISC-V core to the list of cores.

The [NEORV32](https://github.com/stnolting/neorv32) is a `RV32[E/I][M][C]` CPU passing the [RISC-V compliance tests](https://github.com/stnolting/neorv32_riscv_compliance). It comes with a software framework, full-scale [documentation](https://raw.githubusercontent.com/stnolting/neorv32/master/docs/NEORV32.pdf) including the [deployed](https://stnolting.github.io/neorv32/files.html) doxygen documentation of the software framework, performance and FPGA utilization data for different platforms and configurations, example programs and a ready-to-start hardware setup.

The NEORV32 is more like a microcontroller/SoC due to its on-board peripherals. But when all optional modules are disabled via the configuration generics, you have a "naked" RISC-V core.
