### PR TITLE
Add Capability column for new Marketplace filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,118 +6,118 @@ Please add to the list and fix inaccuracies - see our [CONTRIBUTING file](https:
 
 ## Cores
 
-Name | Supplier | Links | Priv. spec | User spec | Primary Language | License
----- | -------- | ----- | ---------- | --------- | ---------------- | -------
-RV32EC_P2 | IQonIC Works | [Website](http://iqonicworks.com/risc-v-ip/) | 1.11 | RV32E[M]C/RV32I[M]C | SystemVerilog | IQonIC Works Commercial License
-RV32IC_P5 | IQonIC Works | [Website](http://iqonicworks.com/risc-v-ip/) | 1.11 | RV32I[M][N][A]C | SystemVerilog | IQonIC Works Commercial License
-RV32EC_FMP5 | IQonIC Works | [Website](http://iqonicworks.com/risc-v-ip/) | Custom | RV32EC | SystemVerilog | IQonIC Works Commercial License
-rocket | SiFive, UCB Bar| [GitHub](https://github.com/freechipsproject/rocket-chip) | 1.11-draft | 2.3-draft | Chisel | BSD
-freedom | SiFive | [GitHub](https://github.com/sifive/freedom) | 1.11-draft | 2.3-draft | Chisel | BSD
-Berkeley Out-of-Order Machine (BOOM) | UCB BAR | [Website](https://boom-core.org/),[GitHub](https://github.com/riscv-boom/riscv-boom) | 1.11-draft | 2.3-draft | Chisel | BSD
-ORCA | VectorBlox | [GitHub](https://github.com/vectorblox/orca) |  | RV32IM | VHDL | BSD
-RI5CY | ETH Zurich, Università di Bologna | [GitHub](https://github.com/pulp-platform/riscv) |  | RV32IMC | SystemVerilog | Solderpad Hardware License v. 0.51
-Ibex (formerly Zero-riscy) | lowRISC | [GitHub](https://github.com/lowRISC/ibex) | 1.11 | RV32I[M]C/RV32E[M]C | SystemVerilog | Apache 2.0
-Ariane | ETH Zurich, Università di Bologna | [Website](https://pulp-platform.github.io/ariane/docs/home/),[GitHub](https://github.com/pulp-platform/ariane) | 1.11-draft | RV64GC | SystemVerilog | Solderpad Hardware License v. 0.51
-Riscy Processors | MIT CSAIL CSG | [Website](http://csg.csail.mit.edu/riscy-e/),[GitHub](https://github.com/csail-csg/riscy) | | | Bluespec | MIT
-RiscyOO | MIT CSAIL CSG | [GitHub](https://github.com/csail-csg/riscy-OOO) | 1.10 | RV64IMAFD | Bluespec | MIT
-Lizard | Cornell CSL BRG | [GitHub](https://github.com/cornell-brg/lizard) | | RV64IM | PyMTL | BSD
-Minerva | LambdaConcept | [GitHub](https://github.com/lambdaconcept/minerva) | 1.10 | RV32I | nMigen | BSD
-OPenV/mriscv | OnChipUIS | [GitHub](https://github.com/onchipuis/mriscv) | | RV32I(?) | Verilog | MIT
-VexRiscv | SpinalHDL | [GitHub](https://github.com/SpinalHDL/VexRiscv) | | RV32I[M][C] | SpinalHDL | MIT
-Roa Logic RV12 | Roa Logic | [GitHub](https://github.com/roalogic/RV12) | 1.9.1 | 2.1 | SystemVerilog | Non-Commercial License
-SCR1 | Syntacore | [GitHub](https://github.com/syntacore/scr1) | 1.10 | 2.2, RV32I/E[MC] | SystemVerilog | SHL v. 2.0
-SCR3 | Syntacore | [Website](https://syntacore.com/page/products/processor-ip/scr3) | 1.10 | RV[32/64]IMC[A], 2.2, milticore | SystemVerilog | commercial
-SCR4 | Syntacore | [Website](https://syntacore.com/page/products/processor-ip/scr4) | 1.10 | RV[32/64]IMCF[DA], 2.2, milticore | SystemVerilog | commercial
-SCR5 | Syntacore | [Website](https://syntacore.com/page/products/processor-ip/scr5) | 1.10 | RV[32/64]IMC[FDA], 2.2, milticore | SystemVerilog | commercial
-SCR7 | Syntacore | [Website](https://syntacore.com/page/products/processor-ip/scr7) | 1.10 | RV64GC, 2.2, milticore | SystemVerilog | commercial
-Hummingbird E200 | Bob Hu | [GitHub](https://github.com/SI-RISCV/e200_opensource) | 1.10 | 2.2, RV32IMAC | Verilog | Apache 2.0
-Shakti | IIT Madras | [Website](http://shakti.org.in/),[GitLab](https://gitlab.com/shaktiproject) | 1.11 | 2.2, RV64IMAFDC | Bluespec | BSD
-ReonV | Lucas Castro | [GitHub](https://github.com/lcbcFoo/ReonV) | | | VHDL | GPL v3
-PicoRV32 | Clifford Wolf | [GitHub](https://github.com/cliffordwolf/picorv32) | | RV32I/E[MC] | Verilog | ISC
-MR1 | Tom Verbeure | [GitHub](https://github.com/tomverbeure/mr1) | | RV32I | SpinalHDL | Unlicense
-SERV | Olof Kindgren | [GitHub](https://github.com/olofk/serv) | | RV32I | Verilog | ISC
-SweRV EH1 | Western Digital Corporation | [GitHub](https://github.com/chipsalliance/Cores-SweRV) | 1.11 | 2.1, RV32IMC | SystemVerilog | Apache 2.0
-SweRV EL2 | Western Digital Corporation | [GitHub](https://github.com/chipsalliance/Cores-SweRV-EL2) | 1.11 | 2.1, RV32IMC | SystemVerilog | Apache 2.0
-SweRV EH2 | Western Digital Corporation | [GitHub](https://github.com/chipsalliance/Cores-SweRV-EH2) | 1.11 | 2.1, RV32IMAC | SystemVerilog | Apache 2.0
-biRISC-V | UltraEmbedded | [GitHub](https://github.com/ultraembedded/biriscv) | 1.11 | RV32I[M] | Verilog | Apache 2.0
-Reve-R | Gavin Stark | [GitHub](https://github.com/atthecodeface/cdl_hardware) | 1.10 | RV32IMAC | CDL | Apache 2.0
-Bk3 | Codasip | [Website](http://www.codasip.com) | 1.10 | RV32EMC / RV32IM[F]C | Verilog | Codasip EULA
-Bk5 | Codasip | [Website](http://www.codasip.com) | 1.10 | RV32IM[F]C / RV64IM[F]C | Verilog | Codasip EULA
-Bk7 | Codasip | [Website](http://www.codasip.com) | 1.10 | RV64IMA[F][D][C] | Verilog | Codasip EULA
-DarkRISCV | Darklife | [GitHub](https://github.com/darklife/darkriscv) | | most of RV32I | Verilog | BSD
-RPU | Domipheus Labs | [GitHub](https://github.com/Domipheus/RPU) | | RV32I | VHDL | Apache 2.0
-RV01 | Stefano Tonello | [OpenCores](https://opencores.org/projects/rv01_riscv_core) | 1.7 | 2.1, RV32IM | VHDL | LPGL
-N22 | Andes | [Website](http://freestart.andestech.com/) | 1.11 | RV32IMAC/EMAC + Andes V5/V5e ext. | Verilog | Andes FreeStart IPEA
-N25F | Andes | [Website](http://www.andestech.com/en/products-solutions/andescore-processors/riscv-n25f/) | 1.11 | RV32GC + Andes V5 ext. | Verilog | Andes Commercial License
-D25F | Andes | [Website](http://www.andestech.com/en/products-solutions/andescore-processors/riscv-d25f/) | 1.11 | RV32GCP + Andes V5 ext. | Verilog | Andes Commercial License
-A25 | Andes | [Website](http://www.andestech.com/en/products-solutions/andescore-processors/riscv-a25/) | 1.11 | RV32GCP + SV32 + Andes V5 ext. | Verilog | Andes Commercial License
-A25MP | Andes | [Website](http://www.andestech.com/en/products-solutions/andescore-processors/riscv-a25mp/) | 1.11 | RV32GCP + SV32 + Andes V5 ext. + Multi-core | Verilog | Andes Commercial License
-NX25F | Andes | [Website](http://www.andestech.com/en/products-solutions/andescore-processors/riscv-nx25f/) | 1.11 | RV64GC + Andes V5 ext. | Verilog | Andes Commercial License
-AX25 | Andes | [Website](http://www.andestech.com/en/products-solutions/andescore-processors/riscv-ax25/) | 1.11 | RV64GCP + SV39/48 + Andes V5 ext. | Verilog | Andes Commercial License
-AX25MP | Andes | [Website](http://www.andestech.com/en/products-solutions/andescore-processors/riscv-ax25mp/) | 1.11 | RV64GCP + SV39/48 + Andes V5 ext. + Multi-core | Verilog | Andes Commercial License
-Instant SoC | FPGA Cores | [Website](http://www.fpga-cores.com/instant-soc/) |  | RV32IM | VHDL | Free Non Commercial
-Taiga | Reconfigurable Computing Lab, Simon Fraser University | [GitLab](https://gitlab.com/sfu-rcl/Taiga) |  | RV32IMA | SystemVerilog | Apache 2.0
-Maestro | João Chrisóstomo | [GitHub](https://github.com/Artoriuz/maestro) | | RV32I | VHDL | MIT
-XuanTie C910 | T-Head (Alibaba group) | [Website](https://www.t-head.cn/product/c910?spm=a2ouz.12987052.0.0.5c5c6245WIbjoG) | 1.10 |  RV64GCV + SV39 + ISA Extension + Memory model Extension + multi-core & multi-cluster(16 cores maximum) | Verilog | Alibaba commercial license
-XuanTie E902 | T-Head (Alibaba group) | [Website](https://www.t-head.cn/product/e902?spm=a2ouz.12987052.0.0.5c5c6245R2yhfA) | 1.10 | RV32EMC/IMC/EC | Verilog | Alibaba commercial license
-BM-310 | CloudBEAR | [Website](https://cloudbear.ru/bm_310.html) | 1.10 | RV32IMC | SystemVerilog | CloudBEAR Commercial License
-BI-350 | CloudBEAR | [Website](https://cloudbear.ru/bi_350.html) | 1.10 | RV32IMAFC + multi-core | SystemVerilog | CloudBEAR Commercial License
-BI-651 | CloudBEAR | [Website](https://cloudbear.ru/bi_651.html) | 1.10 | RV64GC + multi-core | SystemVerilog | CloudBEAR Commercial License
-BI-671 | CloudBEAR | [Website](https://cloudbear.ru/bi_671.html) | 1.10 | RV64GC + multi-core | SystemVerilog | CloudBEAR Commercial License
-SSRV | risclite | [Website](https://risclite.github.io/),[GitHub](https://github.com/risclite/SuperScalar-RISCV-CPU) | 1.10 | RV32IMC | Verilog | Apache 2.0
-Tinyriscv | Blue Liang | [GitHub](https://github.com/liangkangnan/tinyriscv) | | 2.1, RV32I | Verilog | Apache 2.0
-RSD | rsd-devel | [GitHub](https://github.com/rsd-devel/rsd) | | RV32IM | SystemVerilog | Apache 2.0
-Pluto | PQShield | [Website](https://pqsoc.com) | 1.11 | RV32I[M][C] / RV32E[M][C] + Crypto Functions | Verilog | PQShield Commercial License
-E2 | SiFive | [Website](https://www.sifive.com/cores/e24) | 1.11 | RV32I(E)MAFC 2.2 | Verilog | SiFive commercial license
-S2 | SiFive | [Website](https://www.sifive.com/cores/s21) | 1.11 | RV64GC 2.2 | Verilog | SiFive commercial license
-E3 | SiFive | [Website](https://www.sifive.com/cores/e34) | 1.11 | RV32I(E)MAFDC 2.2 | Verilog | SiFive commercial license
-S5 | SiFive | [Website](https://www.sifive.com/cores/s54) | 1.11 | RV64GC 2.2 | Verilog | SiFive commercial license
-U5 | SiFive | [Website](https://www.sifive.com/cores/u54) | 1.11 | RV64GC 2.2 | Verilog | SiFive commercial license
-E7 | SiFive | [Website](https://www.sifive.com/cores/e76) | 1.11 | RV32I(E)MAFDC 2.2 | Verilog | SiFive commercial license
-S7 | SiFive | [Website](https://www.sifive.com/cores/s76) | 1.11 | RV64GC 2.2 | Verilog | SiFive commercial license
-U7 | SiFive | [Website](https://www.sifive.com/cores/u74) | 1.11 | RV64GC 2.2 | Verilog | SiFive commercial license
-Kronos | Sonal Pinto | [GitHub](https://github.com/SonalPinto/kronos) | | RV32I | SystemVerilog | Apache 2.0
-N100 | Nuclei | [Website](https://www.nucleisys.com/product.php) | 1.11 | RV32EC | Verilog | Nuclei commercial license
-N200 | Nuclei | [Website](https://www.nucleisys.com/product.php) | 1.11 | RV32IC(E)(M)(A) | Verilog | Nuclei commercial license
-N300 | Nuclei | [Website](https://www.nucleisys.com/product.php) | 1.11 | RV32IMAC(F)(D)(P) | Verilog | Nuclei commercial license
-N600 | Nuclei | [Website](https://www.nucleisys.com/product.php) | 1.11 | RV32IMAC(F)(D)(P) | Verilog | Nuclei commercial license
-NX600 | Nuclei | [Website](https://www.nucleisys.com/product.php) | 1.11 | RV64IMAC(F)(D)(P) | Verilog | Nuclei commercial license
-UX600 | Nuclei | [Website](https://www.nucleisys.com/product.php) | 1.11 | RV64IMAC(F)(D)(P) + MMU-SV39 | Verilog | Nuclei commercial license
-WH32 | UC Techip | [Website](https://www.uctechip.com/#product) | 1.10 | RV32GCX | Chisel | UC Techip Commercial License
-WARP-V | Steve Hoover, Redwood EDA | [GitHub](https://github.com/stevehoover/warp-v) |  | RV32I[M][F] | TL-Verilog | BSD
-NEORV32 | Stephan Nolting | [GitHub](https://github.com/stnolting/neorv32) | 1.12-draft | 2.2, RV32[I/E][M][C] | VHDL | BSD
-Steel | Rafael Calcada | [GitHub](https://github.com/rafaelcalcada/steel-core) | 1.11 | RV32IZicsr | Verilog | MIT License
+Name | Supplier | Links | Capability | Priv. spec | User spec | Primary Language | License
+---- | -------- | ----- | ---------- | ---------- | --------- | ---------------- | -------
+RV32EC_P2 | IQonIC Works | [Website](http://iqonicworks.com/risc-v-ip/) | RV32 | 1.11 | RV32E[M]C/RV32I[M]C | SystemVerilog | IQonIC Works Commercial License
+RV32IC_P5 | IQonIC Works | [Website](http://iqonicworks.com/risc-v-ip/) | RV32 | 1.11 | RV32I[M][N][A]C | SystemVerilog | IQonIC Works Commercial License
+RV32EC_FMP5 | IQonIC Works | [Website](http://iqonicworks.com/risc-v-ip/) | RV32 | Custom | RV32EC | SystemVerilog | IQonIC Works Commercial License
+rocket | SiFive, UCB Bar| [GitHub](https://github.com/freechipsproject/rocket-chip) | RV32 | 1.11-draft | 2.3-draft | Chisel | BSD
+freedom | SiFive | [GitHub](https://github.com/sifive/freedom) | RV32,RV64 | 1.11-draft | 2.3-draft | Chisel | BSD
+Berkeley Out-of-Order Machine (BOOM) | UCB BAR | [Website](https://boom-core.org/),[GitHub](https://github.com/riscv-boom/riscv-boom) | RV64 | 1.11-draft | 2.3-draft | Chisel | BSD
+ORCA | VectorBlox | [GitHub](https://github.com/vectorblox/orca) | RV32 |  | RV32IM | VHDL | BSD
+RI5CY | ETH Zurich, Università di Bologna | [GitHub](https://github.com/pulp-platform/riscv) | RV32 | |  | RV32IMC | SystemVerilog | Solderpad Hardware License v. 0.51
+Ibex (formerly Zero-riscy) | lowRISC | [GitHub](https://github.com/lowRISC/ibex) | RV32 | 1.11 | RV32I[M]C/RV32E[M]C | SystemVerilog | Apache 2.0
+Ariane | ETH Zurich, Università di Bologna | [Website](https://pulp-platform.github.io/ariane/docs/home/),[GitHub](https://github.com/pulp-platform/ariane) | RV64 | 1.11-draft | RV64GC | SystemVerilog | Solderpad Hardware License v. 0.51
+Riscy Processors | MIT CSAIL CSG | [Website](http://csg.csail.mit.edu/riscy-e/),[GitHub](https://github.com/csail-csg/riscy) | RV32,RV64 | | | Bluespec | MIT
+RiscyOO | MIT CSAIL CSG | [GitHub](https://github.com/csail-csg/riscy-OOO) | RV64 | 1.10 | RV64IMAFD | Bluespec | MIT
+Lizard | Cornell CSL BRG | [GitHub](https://github.com/cornell-brg/lizard) | RV64 | | RV64IM | PyMTL | BSD
+Minerva | LambdaConcept | [GitHub](https://github.com/lambdaconcept/minerva) | RV32 | 1.10 | RV32I | nMigen | BSD
+OPenV/mriscv | OnChipUIS | [GitHub](https://github.com/onchipuis/mriscv) | RV32 | | RV32I(?) | Verilog | MIT
+VexRiscv | SpinalHDL | [GitHub](https://github.com/SpinalHDL/VexRiscv) | RV32 | | RV32I[M][C] | SpinalHDL | MIT
+Roa Logic RV12 | Roa Logic | [GitHub](https://github.com/roalogic/RV12) | RV32 | 1.9.1 | 2.1 | SystemVerilog | Non-Commercial License
+SCR1 | Syntacore | [GitHub](https://github.com/syntacore/scr1) | RV32 | 1.10 | 2.2, RV32I/E[MC] | SystemVerilog | SHL v. 2.0
+SCR3 | Syntacore | [Website](https://syntacore.com/page/products/processor-ip/scr3) | RV32,RV64 | 1.10 | RV[32/64]IMC[A], 2.2, milticore | SystemVerilog | commercial
+SCR4 | Syntacore | [Website](https://syntacore.com/page/products/processor-ip/scr4) | RV32,RV64 | 1.10 | RV[32/64]IMCF[DA], 2.2, milticore | SystemVerilog | commercial
+SCR5 | Syntacore | [Website](https://syntacore.com/page/products/processor-ip/scr5) | RV32,RV64 | 1.10 | RV[32/64]IMC[FDA], 2.2, milticore | SystemVerilog | commercial
+SCR7 | Syntacore | [Website](https://syntacore.com/page/products/processor-ip/scr7) | RV64 | 1.10 | RV64GC, 2.2, milticore | SystemVerilog | commercial
+Hummingbird E200 | Bob Hu | [GitHub](https://github.com/SI-RISCV/e200_opensource) | RV32 | 1.10 | 2.2, RV32IMAC | Verilog | Apache 2.0
+Shakti | IIT Madras | [Website](http://shakti.org.in/),[GitLab](https://gitlab.com/shaktiproject) | RV64 | 1.11 | 2.2, RV64IMAFDC | Bluespec | BSD
+ReonV | Lucas Castro | [GitHub](https://github.com/lcbcFoo/ReonV) | RV32 | | | VHDL | GPL v3
+PicoRV32 | Clifford Wolf | [GitHub](https://github.com/cliffordwolf/picorv32) | RV32 | | RV32I/E[MC] | Verilog | ISC
+MR1 | Tom Verbeure | [GitHub](https://github.com/tomverbeure/mr1) | RV32 | | RV32I | SpinalHDL | Unlicense
+SERV | Olof Kindgren | [GitHub](https://github.com/olofk/serv) | RV32 | | RV32I | Verilog | ISC
+SweRV EH1 | Western Digital Corporation | [GitHub](https://github.com/chipsalliance/Cores-SweRV) | RV32 | 1.11 | 2.1, RV32IMC | SystemVerilog | Apache 2.0
+SweRV EL2 | Western Digital Corporation | [GitHub](https://github.com/chipsalliance/Cores-SweRV-EL2) | RV32 | 1.11 | 2.1, RV32IMC | SystemVerilog | Apache 2.0
+SweRV EH2 | Western Digital Corporation | [GitHub](https://github.com/chipsalliance/Cores-SweRV-EH2) | RV32 | 1.11 | 2.1, RV32IMAC | SystemVerilog | Apache 2.0
+biRISC-V | UltraEmbedded | [GitHub](https://github.com/ultraembedded/biriscv) | RV32 | 1.11 | RV32I[M] | Verilog | Apache 2.0
+Reve-R | Gavin Stark | [GitHub](https://github.com/atthecodeface/cdl_hardware) | RV32 | 1.10 | RV32IMAC | CDL | Apache 2.0
+Bk3 | Codasip | [Website](http://www.codasip.com) | RV32 | 1.10 | RV32EMC / RV32IM[F]C | Verilog | Codasip EULA
+Bk5 | Codasip | [Website](http://www.codasip.com) | RV32 |1.10 | RV32IM[F]C / RV64IM[F]C | Verilog | Codasip EULA
+Bk7 | Codasip | [Website](http://www.codasip.com) | RV64 | 1.10 | RV64IMA[F][D][C] | Verilog | Codasip EULA
+DarkRISCV | Darklife | [GitHub](https://github.com/darklife/darkriscv) | RV32 | | most of RV32I | Verilog | BSD
+RPU | Domipheus Labs | [GitHub](https://github.com/Domipheus/RPU) | RV32 | | RV32I | VHDL | Apache 2.0
+RV01 | Stefano Tonello | [OpenCores](https://opencores.org/projects/rv01_riscv_core) | RV32 | 1.7 | 2.1, RV32IM | VHDL | LPGL
+N22 | Andes | [Website](http://freestart.andestech.com/) | RV32 | 1.11 | RV32IMAC/EMAC + Andes V5/V5e ext. | Verilog | Andes FreeStart IPEA
+N25F | Andes | [Website](http://www.andestech.com/en/products-solutions/andescore-processors/riscv-n25f/) | RV32 | 1.11 | RV32GC + Andes V5 ext. | Verilog | Andes Commercial License
+D25F | Andes | [Website](http://www.andestech.com/en/products-solutions/andescore-processors/riscv-d25f/) | RV32 | 1.11 | RV32GCP + Andes V5 ext. | Verilog | Andes Commercial License
+A25 | Andes | [Website](http://www.andestech.com/en/products-solutions/andescore-processors/riscv-a25/) | RV32 | 1.11 | RV32GCP + SV32 + Andes V5 ext. | Verilog | Andes Commercial License
+A25MP | Andes | [Website](http://www.andestech.com/en/products-solutions/andescore-processors/riscv-a25mp/) | RV32 | 1.11 | RV32GCP + SV32 + Andes V5 ext. + Multi-core | Verilog | Andes Commercial License
+NX25F | Andes | [Website](http://www.andestech.com/en/products-solutions/andescore-processors/riscv-nx25f/) | RV64 | 1.11 | RV64GC + Andes V5 ext. | Verilog | Andes Commercial License
+AX25 | Andes | [Website](http://www.andestech.com/en/products-solutions/andescore-processors/riscv-ax25/) | RV64 | 1.11 | RV64GCP + SV39/48 + Andes V5 ext. | Verilog | Andes Commercial License
+AX25MP | Andes | [Website](http://www.andestech.com/en/products-solutions/andescore-processors/riscv-ax25mp/) | RV64 | 1.11 | RV64GCP + SV39/48 + Andes V5 ext. + Multi-core | Verilog | Andes Commercial License
+Instant SoC | FPGA Cores | [Website](http://www.fpga-cores.com/instant-soc/) | RV32 |  | RV32IM | VHDL | Free Non Commercial
+Taiga | Reconfigurable Computing Lab, Simon Fraser University | [GitLab](https://gitlab.com/sfu-rcl/Taiga) | RV32 |  | RV32IMA | SystemVerilog | Apache 2.0
+Maestro | João Chrisóstomo | [GitHub](https://github.com/Artoriuz/maestro) | RV32 |  | RV32I | VHDL | MIT
+XuanTie C910 | T-Head (Alibaba group) | [Website](https://www.t-head.cn/product/c910?spm=a2ouz.12987052.0.0.5c5c6245WIbjoG) | RV64 | 1.10 |  RV64GCV + SV39 + ISA Extension + Memory model Extension + multi-core & multi-cluster(16 cores maximum) | Verilog | Alibaba commercial license
+XuanTie E902 | T-Head (Alibaba group) | [Website](https://www.t-head.cn/product/e902?spm=a2ouz.12987052.0.0.5c5c6245R2yhfA) | RV32 | 1.10 | RV32EMC/IMC/EC | Verilog | Alibaba commercial license
+BM-310 | CloudBEAR | [Website](https://cloudbear.ru/bm_310.html) | RV32 | 1.10 | RV32IMC | SystemVerilog | CloudBEAR Commercial License
+BI-350 | CloudBEAR | [Website](https://cloudbear.ru/bi_350.html) | RV32 | 1.10 | RV32IMAFC + multi-core | SystemVerilog | CloudBEAR Commercial License
+BI-651 | CloudBEAR | [Website](https://cloudbear.ru/bi_651.html) | RV64 | 1.10 | RV64GC + multi-core | SystemVerilog | CloudBEAR Commercial License
+BI-671 | CloudBEAR | [Website](https://cloudbear.ru/bi_671.html) | RV64 | 1.10 | RV64GC + multi-core | SystemVerilog | CloudBEAR Commercial License
+SSRV | risclite | [Website](https://risclite.github.io/),[GitHub](https://github.com/risclite/SuperScalar-RISCV-CPU) | RV32 | 1.10 | RV32IMC | Verilog | Apache 2.0
+Tinyriscv | Blue Liang | [GitHub](https://github.com/liangkangnan/tinyriscv) | RV32 |  | 2.1, RV32I | Verilog | Apache 2.0
+RSD | rsd-devel | [GitHub](https://github.com/rsd-devel/rsd) | RV32 |  | RV32IM | SystemVerilog | Apache 2.0
+Pluto | PQShield | [Website](https://pqsoc.com) | RV32 | 1.11 | RV32I[M][C] / RV32E[M][C] + Crypto Functions | Verilog | PQShield Commercial License
+E2 | SiFive | [Website](https://www.sifive.com/cores/e24) | RV32 | 1.11 | RV32I(E)MAFC 2.2 | Verilog | SiFive commercial license
+S2 | SiFive | [Website](https://www.sifive.com/cores/s21) | RV64 |1.11 | RV64GC 2.2 | Verilog | SiFive commercial license
+E3 | SiFive | [Website](https://www.sifive.com/cores/e34) | RV32 | 1.11 | RV32I(E)MAFDC 2.2 | Verilog | SiFive commercial license
+S5 | SiFive | [Website](https://www.sifive.com/cores/s54) | RV64 | 1.11 | RV64GC 2.2 | Verilog | SiFive commercial license
+U5 | SiFive | [Website](https://www.sifive.com/cores/u54) | RV64 | 1.11 | RV64GC 2.2 | Verilog | SiFive commercial license
+E7 | SiFive | [Website](https://www.sifive.com/cores/e76) | RV32 | 1.11 | RV32I(E)MAFDC 2.2 | Verilog | SiFive commercial license
+S7 | SiFive | [Website](https://www.sifive.com/cores/s76) | RV64 | 1.11 | RV64GC 2.2 | Verilog | SiFive commercial license
+U7 | SiFive | [Website](https://www.sifive.com/cores/u74) | RV64 | 1.11 | RV64GC 2.2 | Verilog | SiFive commercial license
+Kronos | Sonal Pinto | [GitHub](https://github.com/SonalPinto/kronos) | RV32 | | RV32I | SystemVerilog | Apache 2.0
+N100 | Nuclei | [Website](https://www.nucleisys.com/product.php) | RV32 | 1.11 | RV32EC | Verilog | Nuclei commercial license
+N200 | Nuclei | [Website](https://www.nucleisys.com/product.php) | RV32 | 1.11 | RV32IC(E)(M)(A) | Verilog | Nuclei commercial license
+N300 | Nuclei | [Website](https://www.nucleisys.com/product.php) | RV32 | 1.11 | RV32IMAC(F)(D)(P) | Verilog | Nuclei commercial license
+N600 | Nuclei | [Website](https://www.nucleisys.com/product.php) | RV32 | 1.11 | RV32IMAC(F)(D)(P) | Verilog | Nuclei commercial license
+NX600 | Nuclei | [Website](https://www.nucleisys.com/product.php) | RV32 | 1.11 | RV64IMAC(F)(D)(P) | Verilog | Nuclei commercial license
+UX600 | Nuclei | [Website](https://www.nucleisys.com/product.php) | RV64 | 1.11 | RV64IMAC(F)(D)(P) + MMU-SV39 | Verilog | Nuclei commercial license
+WH32 | UC Techip | [Website](https://www.uctechip.com/#product) | RV32 | 1.10 | RV32GCX | Chisel | UC Techip Commercial License
+WARP-V | Steve Hoover, Redwood EDA | [GitHub](https://github.com/stevehoover/warp-v) | RV32 |  | RV32I[M][F] | TL-Verilog | BSD
+NEORV32 | Stephan Nolting | [GitHub](https://github.com/stnolting/neorv32) | RV32 | 1.12-draft | 2.2, RV32[I/E][M][C] | VHDL | BSD
+Steel | Rafael Calcada | [GitHub](https://github.com/rafaelcalcada/steel-core) | RV32 | 1.11 | RV32IZicsr | Verilog | MIT License
 
 ## SoC platforms
 
-Name | Supplier | Links | Core | License
----- | -------- | ----- | ---- | -------
-Rocket Chip | SiFive, UCB BAR | [GitHub](https://github.com/freechipsproject/rocket-chip),[Simulator](https://fires.im) | Rocket | BSD
-LowRISC | lowRISC | [GitHub](https://github.com/lowRISC/lowrisc-chip) | RV32IM | BSD
-PULPino | ETH Zurich, Università di Bologna | [Website](http://www.pulp-platform.org),[GitHub](https://github.com/pulp-platform/pulpino) | RI5CY, Zero-riscy | Solderpad Hardware License v. 0.51
-PULPissimo | ETH Zurich, Università di Bologna | [Website](http://www.pulp-platform.org),[GitHub](https://github.com/pulp-platform/pulpissimo) | RI5CY, Zero-riscy | Solderpad Hardware License v. 0.51
-Ariane SoC | ETH Zurich, Università di Bologna | [Website](http://www.pulp-platform.org),[GitHub](https://github.com/pulp-platform/ariane) | Ariane | Solderpad Hardware License v. 0.51
-OPENPULP | ETH Zurich, Università di Bologna | [Website](http://www.pulp-platform.org),[GitHub](https://github.com/pulp-platform/pulp) | RI5CY, Zero-riscy | Solderpad Hardware License v. 0.51
-HERO | ETH Zurich, Università di Bologna | [Website](http://www.pulp-platform.org),[GitHub](https://github.com/pulp-platform/bigpulp) | RI5CY, Zero-riscy | Solderpad Hardware License v. 0.51
-OpenPiton + Ariane | Princeton Parallel Group, ETH Zurich, Università di Bologna | [Website](https://parallel.princeton.edu/openpiton/),[GitHub](https://github.com/PrincetonUniversity/openpiton) | Ariane | Solderpad Hardware License v. 0.51, BSD
-Briey | SpinalHDL | [GitHub](https://github.com/SpinalHDL/VexRiscv#briey-soc) | VexRiscv | MIT
-Riscy | AleksandarKostovic | [GitHub](https://github.com/AleksandarKostovic/Riscy-SoC) | RV64I | MIT
-Raven | RTimothyEdwards, mkkassem (efabless.com) | [GitHub](https://github.com/efabless/picorv32-soc-raven) | PicoRV32 | ISC
-PicoSoC | Clifford Wolf | [GitHub](https://github.com/cliffordwolf/picorv32/tree/master/picosoc) | PicoRV32 | ISC
-Icicle | Graham Edgecombe | [GitHub](https://github.com/grahamedgecombe/icicle) | RV32I | ISC
-MIV RV32IMA L1 AHB | Microchip | [Documentation](http://www.microsemi.com/index.php?option=com_docman&task=doc_download&gid=1243779), [IDE](https://www.microsemi.com/product-directory/design-tools/4879-softconsole), [Development Environment](https://www.microsemi.com/product-directory/design-resources/1750-libero-soc) | Rocket RV32IMA | Apache 2.0
-MIV RV32IMA L1 AXI | Microchip | [Documentation](http://www.microsemi.com/index.php?option=com_docman&task=doc_download&gid=1243780), [IDE](https://www.microsemi.com/product-directory/design-tools/4879-softconsole), [Development Environment](https://www.microsemi.com/product-directory/design-resources/1750-libero-soc) | Rocket RV32IMA | Apache 2.0
-MIV RV32IMAF L1 AHB | Microchip | [Documentation](http://www.microsemi.com/index.php?option=com_docman&task=doc_download&gid=1243781), [IDE](https://www.microsemi.com/product-directory/design-tools/4879-softconsole), [Development Environment](https://www.microsemi.com/product-directory/design-resources/1750-libero-soc) | Rocket RV32IMAF | Apache 2.0
-MIV RV32IMC | Microchip | [Documentation](https://www.microsemi.com/document-portal/doc_download/1244850-mi-vrv32imc), [IDE](https://www.microsemi.com/product-directory/design-tools/4879-softconsole), [Development Environment](https://www.microsemi.com/product-directory/design-resources/1750-libero-soc) | Submicron RV32I, RV32IC, RV32IM, RV32IMC | Apache 2.0
-FreeStart AE250 | Andes | [Website](http://freestart.andestech.com/) | N22 | Andes FreeStart: Free for Evaluation
-Standard AE250 | Andes | [Website](http://www.andestech.com/en/products-solutions/andeshape-platforms/ae250-ahb-based-platform-pre-integrated-with-n22/), [IDE](http://www.andestech.com/en/products-solutions/andesight-ide/) | N22 | Andes Commerical License
-AE350 | Andes | [Website](http://www.andestech.com/en/products-solutions/andeshape-platforms/ae350-axi-based-platform-pre-integrated-with-n25f-nx25f-a25-ax25/), [IDE](http://www.andestech.com/en/products-solutions/andesight-ide/) | N25F, D25F, A25, A25MP, NX25F, AX25, AX25MP | Andes Commerical License
-SCR1 SDK | Syntacore | [GitHub](https://github.com/syntacore/scr1-sdk) | SCR1, SCRx | SHL 2.0
-ESP | SLD Group, Columbia University | [Website](https://esp.cs.columbia.edu), [GitHub](https://github.com/sld-columbia/esp) | Ariane | Apache 2.0
-Chipyard | UCB BAR | [GitHub](https://github.com/ucb-bar/chipyard),[Documentation](https://chipyard.readthedocs.io/en/latest/) | Rocket, BOOM | BSD
-PQSoC | PQShield | [Website](https://pqsoc.com) | Pluto | PQShield Commercial License
-KRZ | Sonal Pinto | [GitHub](https://github.com/SonalPinto/kronos) | Kronos | Apache 2.0
-IOb-SoC | IObundle | [GitHub](https://github.com/IObundle/iob-soc) | PicoRV32 | MIT
+Name | Supplier | Links | Capability | Core | License
+---- | -------- | ----- | ---------- | ---- | -------
+Rocket Chip | SiFive, UCB BAR | [GitHub](https://github.com/freechipsproject/rocket-chip),[Simulator](https://fires.im) | RV32 |Rocket | BSD
+LowRISC | lowRISC | [GitHub](https://github.com/lowRISC/lowrisc-chip) | RV32 | RV32IM | BSD
+PULPino | ETH Zurich, Università di Bologna | [Website](http://www.pulp-platform.org),[GitHub](https://github.com/pulp-platform/pulpino) | RV32 | RI5CY, Zero-riscy | Solderpad Hardware License v. 0.51
+PULPissimo | ETH Zurich, Università di Bologna | [Website](http://www.pulp-platform.org),[GitHub](https://github.com/pulp-platform/pulpissimo) | RV32 |RI5CY, Zero-riscy | Solderpad Hardware License v. 0.51
+Ariane SoC | ETH Zurich, Università di Bologna | [Website](http://www.pulp-platform.org),[GitHub](https://github.com/pulp-platform/ariane) | RV64 | Ariane | Solderpad Hardware License v. 0.51
+OPENPULP | ETH Zurich, Università di Bologna | [Website](http://www.pulp-platform.org),[GitHub](https://github.com/pulp-platform/pulp) | RV32 | RI5CY, Zero-riscy | Solderpad Hardware License v. 0.51
+HERO | ETH Zurich, Università di Bologna | [Website](http://www.pulp-platform.org),[GitHub](https://github.com/pulp-platform/bigpulp) | RV32 | RI5CY, Zero-riscy | Solderpad Hardware License v. 0.51
+OpenPiton + Ariane | Princeton Parallel Group, ETH Zurich, Università di Bologna | [Website](https://parallel.princeton.edu/openpiton/),[GitHub](https://github.com/PrincetonUniversity/openpiton) | RV64 | Ariane | Solderpad Hardware License v. 0.51, BSD
+Briey | SpinalHDL | [GitHub](https://github.com/SpinalHDL/VexRiscv#briey-soc) | RV32 | VexRiscv | MIT
+Riscy | AleksandarKostovic | [GitHub](https://github.com/AleksandarKostovic/Riscy-SoC) | RV64 | RV64I | MIT
+Raven | RTimothyEdwards, mkkassem (efabless.com) | [GitHub](https://github.com/efabless/picorv32-soc-raven) | RV32 | PicoRV32 | ISC
+PicoSoC | Clifford Wolf | [GitHub](https://github.com/cliffordwolf/picorv32/tree/master/picosoc) | RV32 | PicoRV32 | ISC
+Icicle | Graham Edgecombe | [GitHub](https://github.com/grahamedgecombe/icicle) | RV32 | RV32I | ISC
+MIV RV32IMA L1 AHB | Microchip | [Documentation](http://www.microsemi.com/index.php?option=com_docman&task=doc_download&gid=1243779), [IDE](https://www.microsemi.com/product-directory/design-tools/4879-softconsole), [Development Environment](https://www.microsemi.com/product-directory/design-resources/1750-libero-soc) | RV32 | Rocket RV32IMA | Apache 2.0
+MIV RV32IMA L1 AXI | Microchip | [Documentation](http://www.microsemi.com/index.php?option=com_docman&task=doc_download&gid=1243780), [IDE](https://www.microsemi.com/product-directory/design-tools/4879-softconsole), [Development Environment](https://www.microsemi.com/product-directory/design-resources/1750-libero-soc) | RV32 | Rocket RV32IMA | Apache 2.0
+MIV RV32IMAF L1 AHB | Microchip | [Documentation](http://www.microsemi.com/index.php?option=com_docman&task=doc_download&gid=1243781), [IDE](https://www.microsemi.com/product-directory/design-tools/4879-softconsole), [Development Environment](https://www.microsemi.com/product-directory/design-resources/1750-libero-soc) | RV32 | Rocket RV32IMAF | Apache 2.0
+MIV RV32IMC | Microchip | [Documentation](https://www.microsemi.com/document-portal/doc_download/1244850-mi-vrv32imc), [IDE](https://www.microsemi.com/product-directory/design-tools/4879-softconsole), [Development Environment](https://www.microsemi.com/product-directory/design-resources/1750-libero-soc) | RV32 | Submicron RV32I, RV32IC, RV32IM, RV32IMC | Apache 2.0
+FreeStart AE250 | Andes | [Website](http://freestart.andestech.com/) | RV32 | N22 | Andes FreeStart: Free for Evaluation
+Standard AE250 | Andes | [Website](http://www.andestech.com/en/products-solutions/andeshape-platforms/ae250-ahb-based-platform-pre-integrated-with-n22/), [IDE](http://www.andestech.com/en/products-solutions/andesight-ide/) | RV32 | N22 | Andes Commerical License
+AE350 | Andes | [Website](http://www.andestech.com/en/products-solutions/andeshape-platforms/ae350-axi-based-platform-pre-integrated-with-n25f-nx25f-a25-ax25/), [IDE](http://www.andestech.com/en/products-solutions/andesight-ide/) | RV64 | N25F, D25F, A25, A25MP, NX25F, AX25, AX25MP | Andes Commerical License
+SCR1 SDK | Syntacore | [GitHub](https://github.com/syntacore/scr1-sdk) | RV32 | SCR1, SCRx | SHL 2.0
+ESP | SLD Group, Columbia University | [Website](https://esp.cs.columbia.edu), [GitHub](https://github.com/sld-columbia/esp) | RV64 | Ariane | Apache 2.0
+Chipyard | UCB BAR | [GitHub](https://github.com/ucb-bar/chipyard),[Documentation](https://chipyard.readthedocs.io/en/latest/) | RV64 | Rocket, BOOM | BSD
+PQSoC | PQShield | [Website](https://pqsoc.com) | RV32 | Pluto | PQShield Commercial License
+KRZ | Sonal Pinto | [GitHub](https://github.com/SonalPinto/kronos) | RV32 | Kronos | Apache 2.0
+IOb-SoC | IObundle | [GitHub](https://github.com/IObundle/iob-soc) | RV32 | PicoRV32 | MIT
 
 ## SoCs
 


### PR DESCRIPTION
Per the conversation of the TG-Content group from 30JLY2020,
this PR adds the Capability column for the Cores and SoC tables
to allow selection by RV32, RV64, or RV128 (no entries match
RV128). Some of the entires support both RV32 and RV64, which I
added by comma separating the two values in the column. I do not
know if the search plugin can handle that, if it cannot please
let me know and I will duplicate the rows for both capabilities.