### PR TITLE
Added the Klessydra Core Family to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Please add to the list and fix inaccuracies - see our [CONTRIBUTING file](https:
 
 Name | Supplier | Links | Capability | Priv. spec | User spec | Primary Language | License
 ---- | -------- | ----- | ---------- | ---------- | --------- | ---------------- | -------
+Klessydra-T13 | Digital Systems Lab at Sapienza University of Rome | [GitHub](https://github.com/klessydra/T13x) | RV32 | 1.11 | RV32I/E[M][A] + Kless-Vect | VHDL-2008 | Solderpad Hardware License v. 0.51
+Klessydra-T03 | Digital Systems Lab at Sapienza University of Rome | [GitHub](https://github.com/klessydra/T03x) | RV32 | 1.11 | RV32I[A] | VHDL-2008 | Solderpad Hardware License v. 0.51
+Klessydra-T02 | Digital Systems Lab at Sapienza University of Rome | [GitHub](https://github.com/klessydra/T02x) | RV32 | 1.11 | RV32I[A] | VHDL-2008 | Solderpad Hardware License v. 0.51
+Klessydra-F03 | Digital Systems Lab at Sapienza University of Rome | [GitHub](https://github.com/klessydra/F03x) | RV32 | 1.11 | RV32I[A] | VHDL-2008 | Solderpad Hardware License v. 0.51
 RV32EC_P2 | IQonIC Works | [Website](http://iqonicworks.com/risc-v-ip/) | RV32 | 1.11 | RV32E[M]C/RV32I[M]C | SystemVerilog | IQonIC Works Commercial License
 RV32IC_P5 | IQonIC Works | [Website](http://iqonicworks.com/risc-v-ip/) | RV32 | 1.11 | RV32I[M][N][A]C | SystemVerilog | IQonIC Works Commercial License
 RV32EC_FMP5 | IQonIC Works | [Website](http://iqonicworks.com/risc-v-ip/) | RV32 | Custom | RV32EC | SystemVerilog | IQonIC Works Commercial License

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ WH32 | UC Techip | [Website](https://www.uctechip.com/#product) | RV32 | 1.10 | 
 WARP-V | Steve Hoover, Redwood EDA | [GitHub](https://github.com/stevehoover/warp-v) | RV32 |  | RV32I[M][F] | TL-Verilog | BSD
 NEORV32 | Stephan Nolting | [GitHub](https://github.com/stnolting/neorv32) | RV32 | 1.12-draft | 2.2, RV32[I/E][M][C] | VHDL | BSD
 Steel | Rafael Calcada | [GitHub](https://github.com/rafaelcalcada/steel-core) | RV32 | 1.11 | RV32IZicsr | Verilog | MIT License
-Klessydra-T13 | Digital Systems Lab at Sapienza University of Rome | [GitHub](https://github.com/klessydra/T13x) | RV32 | 1.11 | RV32I/E[M][A] + Kless-Vect | VHDL-2008 | Solderpad Hardware License v. 0.51
+Klessydra-T13 | Digital Systems Lab at Sapienza University of Rome | [GitHub](https://github.com/klessydra/T13x) | RV32 | 1.11 | RV32[I/E][M][A] + Kless-Vect | VHDL-2008 | Solderpad Hardware License v. 0.51
 Klessydra-T03 | Digital Systems Lab at Sapienza University of Rome | [GitHub](https://github.com/klessydra/T03x) | RV32 | 1.11 | RV32I[A] | VHDL-2008 | Solderpad Hardware License v. 0.51
 Klessydra-T02 | Digital Systems Lab at Sapienza University of Rome | [GitHub](https://github.com/klessydra/T02x) | RV32 | 1.11 | RV32I[A] | VHDL-2008 | Solderpad Hardware License v. 0.51
 Klessydra-F03 | Digital Systems Lab at Sapienza University of Rome | [GitHub](https://github.com/klessydra/F03x) | RV32 | 1.11 | RV32I[A] | VHDL-2008 | Solderpad Hardware License v. 0.51

--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ Please add to the list and fix inaccuracies - see our [CONTRIBUTING file](https:
 
 Name | Supplier | Links | Capability | Priv. spec | User spec | Primary Language | License
 ---- | -------- | ----- | ---------- | ---------- | --------- | ---------------- | -------
-Klessydra-T13 | Digital Systems Lab at Sapienza University of Rome | [GitHub](https://github.com/klessydra/T13x) | RV32 | 1.11 | RV32I/E[M][A] + Kless-Vect | VHDL-2008 | Solderpad Hardware License v. 0.51
-Klessydra-T03 | Digital Systems Lab at Sapienza University of Rome | [GitHub](https://github.com/klessydra/T03x) | RV32 | 1.11 | RV32I[A] | VHDL-2008 | Solderpad Hardware License v. 0.51
-Klessydra-T02 | Digital Systems Lab at Sapienza University of Rome | [GitHub](https://github.com/klessydra/T02x) | RV32 | 1.11 | RV32I[A] | VHDL-2008 | Solderpad Hardware License v. 0.51
-Klessydra-F03 | Digital Systems Lab at Sapienza University of Rome | [GitHub](https://github.com/klessydra/F03x) | RV32 | 1.11 | RV32I[A] | VHDL-2008 | Solderpad Hardware License v. 0.51
 RV32EC_P2 | IQonIC Works | [Website](http://iqonicworks.com/risc-v-ip/) | RV32 | 1.11 | RV32E[M]C/RV32I[M]C | SystemVerilog | IQonIC Works Commercial License
 RV32IC_P5 | IQonIC Works | [Website](http://iqonicworks.com/risc-v-ip/) | RV32 | 1.11 | RV32I[M][N][A]C | SystemVerilog | IQonIC Works Commercial License
 RV32EC_FMP5 | IQonIC Works | [Website](http://iqonicworks.com/risc-v-ip/) | RV32 | Custom | RV32EC | SystemVerilog | IQonIC Works Commercial License
@@ -90,6 +86,10 @@ WH32 | UC Techip | [Website](https://www.uctechip.com/#product) | RV32 | 1.10 | 
 WARP-V | Steve Hoover, Redwood EDA | [GitHub](https://github.com/stevehoover/warp-v) | RV32 |  | RV32I[M][F] | TL-Verilog | BSD
 NEORV32 | Stephan Nolting | [GitHub](https://github.com/stnolting/neorv32) | RV32 | 1.12-draft | 2.2, RV32[I/E][M][C] | VHDL | BSD
 Steel | Rafael Calcada | [GitHub](https://github.com/rafaelcalcada/steel-core) | RV32 | 1.11 | RV32IZicsr | Verilog | MIT License
+Klessydra-T13 | Digital Systems Lab at Sapienza University of Rome | [GitHub](https://github.com/klessydra/T13x) | RV32 | 1.11 | RV32I/E[M][A] + Kless-Vect | VHDL-2008 | Solderpad Hardware License v. 0.51
+Klessydra-T03 | Digital Systems Lab at Sapienza University of Rome | [GitHub](https://github.com/klessydra/T03x) | RV32 | 1.11 | RV32I[A] | VHDL-2008 | Solderpad Hardware License v. 0.51
+Klessydra-T02 | Digital Systems Lab at Sapienza University of Rome | [GitHub](https://github.com/klessydra/T02x) | RV32 | 1.11 | RV32I[A] | VHDL-2008 | Solderpad Hardware License v. 0.51
+Klessydra-F03 | Digital Systems Lab at Sapienza University of Rome | [GitHub](https://github.com/klessydra/F03x) | RV32 | 1.11 | RV32I[A] | VHDL-2008 | Solderpad Hardware License v. 0.51
 
 ## SoC platforms
 


### PR DESCRIPTION
Hello. I went ahead and added the open-source klessydra cores to the list in the table. 

They are the following:

Klessydra-T13 
Klessydra-T03 
Klessydra-T02 
Klessydra-F03 