### PR TITLE
Add SoC platform "NEORV32 Processor"

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ PQSoC | PQShield | [Website](https://pqsoc.com) | RV32 | Pluto | PQShield Commer
 KRZ | Sonal Pinto | [GitHub](https://github.com/SonalPinto/kronos) | RV32 | Kronos | Apache 2.0
 IOb-SoC | IObundle | [GitHub](https://github.com/IObundle/iob-soc) | RV32 | PicoRV32 | MIT
 SweRVolf | CHIPS Alliance | [GitHub](https://github.com/chipsalliance/Cores-SweRVolf) | RV32 | SweRV EH1, SweRV EL2 | Apache 2.0
+NEORV32 Processor | Stephan Nolting | [GitHub](https://github.com/stnolting/neorv32) | RV32 | NEORV32 | BSD
 
 
 ## SoCs

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ NX600 | Nuclei | [Website](https://www.nucleisys.com/product.php) | RV32 | 1.11 
 UX600 | Nuclei | [Website](https://www.nucleisys.com/product.php) | RV64 | 1.11 | RV64IMAC(F)(D)(P) + MMU-SV39 | Verilog | Nuclei commercial license
 WH32 | UC Techip | [Website](https://www.uctechip.com/#product) | RV32 | 1.10 | RV32GCX | Chisel | UC Techip Commercial License
 WARP-V | Steve Hoover, Redwood EDA | [GitHub](https://github.com/stevehoover/warp-v) | RV32 |  | RV32I[M][F] | TL-Verilog | BSD
-NEORV32 | Stephan Nolting | [GitHub](https://github.com/stnolting/neorv32) | RV32 | 1.12-draft | 2.2, RV32[I/E][M][C] | VHDL | BSD
+NEORV32 | Stephan Nolting | [GitHub](https://github.com/stnolting/neorv32) | RV32 | 1.12-draft | 2.2, RV32[I/E][M][C][Zicsr][Zifencei] | VHDL | BSD
 Steel | Rafael Calcada | [GitHub](https://github.com/rafaelcalcada/steel-core) | RV32 | 1.11 | RV32IZicsr | Verilog | MIT License
 Klessydra-T13 | Digital Systems Lab at Sapienza University of Rome | [GitHub](https://github.com/klessydra/T13x) | RV32 | 1.11 | RV32[I/E][M][A] + Kless-Vect | VHDL-2008 | Solderpad Hardware License v. 0.51
 Klessydra-T03 | Digital Systems Lab at Sapienza University of Rome | [GitHub](https://github.com/klessydra/T03x) | RV32 | 1.11 | RV32I[A] | VHDL-2008 | Solderpad Hardware License v. 0.51

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ NX600 | Nuclei | [Website](https://www.nucleisys.com/product.php) | RV32 | 1.11 
 UX600 | Nuclei | [Website](https://www.nucleisys.com/product.php) | RV64 | 1.11 | RV64IMAC(F)(D)(P) + MMU-SV39 | Verilog | Nuclei commercial license
 WH32 | UC Techip | [Website](https://www.uctechip.com/#product) | RV32 | 1.10 | RV32GCX | Chisel | UC Techip Commercial License
 WARP-V | Steve Hoover, Redwood EDA | [GitHub](https://github.com/stevehoover/warp-v) | RV32 |  | RV32I[M][F] | TL-Verilog | BSD
-NEORV32 | Stephan Nolting | [GitHub](https://github.com/stnolting/neorv32) | RV32 | 1.12-draft | 2.2, RV32[I/E][M][C][Zicsr][Zifencei] | VHDL | BSD
+NEORV32 | Stephan Nolting | [GitHub](https://github.com/stnolting/neorv32) | RV32 | 1.12-draft | 2.2, RV32[I/E][M][A][C][Zicsr][Zifencei] | VHDL | BSD
 Steel | Rafael Calcada | [GitHub](https://github.com/rafaelcalcada/steel-core) | RV32 | 1.11 | RV32IZicsr | Verilog | MIT License
 Klessydra-T13 | Digital Systems Lab at Sapienza University of Rome | [GitHub](https://github.com/klessydra/T13x) | RV32 | 1.11 | RV32[I/E][M][A] + Kless-Vect | VHDL-2008 | Solderpad Hardware License v. 0.51
 Klessydra-T03 | Digital Systems Lab at Sapienza University of Rome | [GitHub](https://github.com/klessydra/T03x) | RV32 | 1.11 | RV32I[A] | VHDL-2008 | Solderpad Hardware License v. 0.51


### PR DESCRIPTION
Is it okay to have the **same** repository for the *core* and the *SoC platform*? 🤔 

Both, the *NEORV32 Processor* (the actual SoC) and the *NEORV32* (the core/CPU) are located in [github.com/stnolting/neorv32](https://github.com/stnolting/neorv32).
By setting the configuration generics of the top entity you can either get a full-scale SoC (the "processor") or just the CPU with a handy bus interface (all further CPU signals like interrupts are propagated to the top entity).