### PR TITLE
Added "Zfinx" extension to NEORV32 core

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ NX600 | Nuclei | [Website](https://www.nucleisys.com/product.php) | RV32 | 1.11 
 UX600 | Nuclei | [Website](https://www.nucleisys.com/product.php) | RV64 | 1.11 | RV64IMAC(F)(D)(P) + MMU-SV39 | Verilog | Nuclei commercial license
 WH32 | UC Techip | [Website](https://www.uctechip.com/#product) | RV32 | 1.10 | RV32GCX | Chisel | UC Techip Commercial License
 WARP-V | Steve Hoover, Redwood EDA | [GitHub](https://github.com/stevehoover/warp-v) | RV32 |  | RV32I[M][F] | TL-Verilog | BSD
-NEORV32 | Stephan Nolting | [GitHub](https://github.com/stnolting/neorv32) | RV32 | 1.12-draft | 2.2, RV32[I/E][M][A][C][Zicsr][Zifencei] | VHDL | BSD
+NEORV32 | Stephan Nolting | [GitHub](https://github.com/stnolting/neorv32) | RV32 | 1.12-draft | 2.2, RV32[I/E][M][A][C][Zfinx][Zicsr][Zifencei] | VHDL | BSD
 Steel | Rafael Calcada | [GitHub](https://github.com/rafaelcalcada/steel-core) | RV32 | 1.11 | RV32IZicsr | Verilog | MIT License
 Klessydra-T13 | Digital Systems Lab at Sapienza University of Rome | [GitHub](https://github.com/klessydra/T13x) | RV32 | 1.11 | RV32[I/E][M][A] + Kless-Vect | VHDL-2008 | Solderpad Hardware License v. 0.51
 Klessydra-T03 | Digital Systems Lab at Sapienza University of Rome | [GitHub](https://github.com/klessydra/T03x) | RV32 | 1.11 | RV32I[A] | VHDL-2008 | Solderpad Hardware License v. 0.51


### PR DESCRIPTION
I have added a single-precision floating-point unit implementing the "official" [RISC-V `Zfinx` extension](https://github.com/riscv/riscv-zfinx). `Zfinx` is not supported by upstream GCC yet (and is not even ratified - but expected to remain unchanged) so I have added an **intrinsic library**  to allow utilization of the extension using a standard `rv32i` tool chain.

In case you want/need/*require* more information:
* Software sources: [https://github.com/stnolting/neorv32/tree/master/sw/example/floating_point_test](https://github.com/stnolting/neorv32/tree/master/sw/example/floating_point_test)
* Software documentation: [NEORV32 GitHub pages / Zfinx intrinsic library](https://stnolting.github.io/neorv32/neorv32__zfinx__extension__intrinsics_8h.html)
* Rationale: [hackaday.io/neorv32](https://hackaday.io/project/174167-the-neorv32-risc-v-processor/log/190808-an-ieee-754-floating-point-unit-for-the-neorv32)

Cheers :wink: